### PR TITLE
Remove $method property from Module Installer code example

### DIFF
--- a/docs/development/addon-installer.md
+++ b/docs/development/addon-installer.md
@@ -56,21 +56,7 @@ Additional functionality can be installed using the following guidelines:
                     'method' => 'action_function', // required
                     'csrf_exempt' => true
                 ]
-        ];
-
-        // defines an extension's methods and hooks that should be installed
-        public $methods = [
-            [
-                'method' => 'run', // will default to same as hook if not defined
-                'hook' => 'template_fetch_template' // required
-                'priority' => ""
-                'enabled' => "" // y/n
-            ],
-            [
-                'method' => 'cleanup', // will default to same as hook if not defined
-                'hook' => 'template_post_parse' // required
-            ]
-        ];    
+        ];   
 
 
         /**
@@ -113,9 +99,9 @@ Extension files can now be as simplified as well. However they must include the 
         public $methods = [
             [
                 'method' => 'run', // will default to same as hook if not defined
-                'hook' => 'template_fetch_template' // required
-                'priority' => ""
-                'enabled' => "" // y/n
+                'hook' => 'template_fetch_template', // required
+                'priority' => "",
+                'enabled' => "", // y/n
             ],
             [
                 'method' => 'cleanup', // will default to same as hook if not defined


### PR DESCRIPTION
<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

Fixes code example for Module Installer that now uses the Addon Installer introduced in v6.

<!-- If this pull request resolves a project issue, provide a link: -->
<!-- Resolves [#NN](https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/issues/NN). -->

## Nature of This Change

<!-- Check all that apply: -->

- [ x ] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ x ] 🛁 Rewrites existing documentation
- [ x ] 💅 Fixes coding style
- [ ] 🔥 Removes unused files / code

<!-- 
## Related Application Change -->
<!-- Required when this is associated with an application pull request -->
<!-- Application Pull Request: https://github.com/ExpressionEngine/ExpressionEngine/pulls/NNN -->

<!-- If you have not already, please sign the Contributor License Agreement: https://www.clahub.com/agreements/ExpressionEngine/ExpressionEngine-User-Guide

Thank you for contributing to the ExpressionEngine User Guide! -->
